### PR TITLE
Correct case of SINCE variable

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -54,5 +54,5 @@ if [ ! -d ".git" ]; then
 	done
 
 else
-	git log --since "$since" --all --abbrev-commit --no-merges --oneline --committer="$AUTHOR" --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'
+	git log --since "$SINCE" --all --abbrev-commit --no-merges --oneline --committer="$AUTHOR" --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'
 fi


### PR DESCRIPTION
This change corrects the case of SINCE making the command valid, as "$since" is not defined but "$SINCE" is.