### PR TITLE
Makefile: fix 'make install' for alternate prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
 prefix=/usr/local
+exec_prefix=$(prefix)
+bindir=$(exec_prefix)/bin
+datarootdir=$(prefix)/share
+datadir=$(datarootdir)
+mandir=$(datarootdir)/man
 
 # files that need mode 755
 EXEC_FILES=git-standup
+
+.PHONY: all install uninstall
 
 all:
 	@echo "usage: make install"
 	@echo "       make uninstall"
 
 install:
-	install -m 0755 $(EXEC_FILES) $(prefix)/bin
+	mkdir -p $(bindir)
+	install -m 0755 $(EXEC_FILES) $(bindir)
 
 uninstall:
-	test -d $(prefix)/bin && \
-	cd $(prefix)/bin && \
+	test -d $(bindir) && \
+	cd $(bindir) && \
 	rm -f $(EXEC_FILES)


### PR DESCRIPTION
The Makefile currently supports `prefix`, but it will balk if the directories under `prefix` do not already exist.

```
$ make install prefix=/tmp/test-prefix
install -m 0755 git-standup /tmp/test-prefix/bin
install: /tmp/test-prefix/bin: No such file or directory
make: *** [install] Error 71
```

This adds a directory creation step. It also sets up some more directory variables based on [GNU's Makefile conventions](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables) in the expectation of later supporting a `man` page and other stuff in conjunction with `prefix` and package managers, like requested in #9.