### PR TITLE
Installer: Take only recent snapshot in git clone

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## Clone the repo
-git clone https://github.com/kamranahmedse/git-standup.git || { echo >&2 "Clone failed with $?"; exit 1; }
+git clone https://github.com/kamranahmedse/git-standup.git --depth=1 || { echo >&2 "Clone failed with $?"; exit 1; }
 cd git-standup
 make install || { echo >&2 "Clone failed with $?"; exit 1; }
 cd ..


### PR DESCRIPTION
Improve the installation speed by fetching only latest snapshot of the source file. This will be particularly useful in slow networks.