### PR TITLE
Make as a node package to make easy to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ $ cd git-standup
 $ sudo make install
 ```
 
+Or you can install with npm
+
+```
+$ npm install -g git-standup
+```
+
 ## Usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "git-standup",
+  "version": "2.1.0",
+  "description": "Recall what you did on the last working day. Psst! or be nosy and find what someone else in your team did ;-)",
+  "main": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "bin": {
+    "git-standup": "./git-standup"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kamranahmedse/git-standup.git"
+  },
+  "keywords": [
+    "git",
+    "standup"
+  ],
+  "author": "Kamran Ahmed",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kamranahmedse/git-standup/issues"
+  },
+  "homepage": "https://github.com/kamranahmedse/git-standup#readme"
+}


### PR DESCRIPTION
Anyone can install easily with npm like below with this patch.

```
$ npm install -g git-standup
```

I added it on npmjs.com for testing https://www.npmjs.com/package/git-standup

Of course, if you want, I'll remove the npm package and then you can add it on npmjs. :-)

And we can use this more useful with below packages;

- https://www.npmjs.com/package/mgit
- https://www.npmjs.com/package/clone-org-repos
