### PR TITLE
Add explicit -h "help" option and longer usage message

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -2,15 +2,44 @@
 
 set -e
 
-## Get the options and store them in variables
-while getopts "d::a::w::" opt; do
-  declare "option_$opt=${OPTARG:-0}"
-done
+## Parse command line
+function usage() {
+  cat <<EOS
+Usage: 
+  git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-h]
 
-## If some options were given but none of them were the ones that we allow 
-if [[ ! $option_a ]] && [[ ! $option_d ]] && [[ ! $option_w ]] &&  [[ $# -gt 0 ]] ; then
-  >&2 echo -e "Usage: $0 [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>]\nExample: $0 -a \"John Doe\" -w \"MON-FRI\""
+  -a      - Specify author to restrict search to
+  -w      - Specify weekday range to limit search to
+  -h      - Display this help screen
+
+Examples:
+  git standup -a "John Doe" -w "MON-FRI"
+EOS
+}
+
+while getopts "hd:a:w:" opt; do
+  case $opt in
+    h|d|a|w)
+      declare "option_$opt=${OPTARG:-0}"
+      ;;
+    \?)
+      echo >&2 "Use 'git standup -h' to see usage info"
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+if [[ $# -gt 0 ]]; then
+  echo >&2 "Invalid arguments: $@"
+  echo >&2 "Use 'git standup -h' to see usage info"
   exit 1
+fi
+
+# Main script
+
+if [[ $option_h ]]; then
+  usage
+  exit 0
 fi
 
 # Use colors, but only if connected to a terminal, and that terminal


### PR DESCRIPTION
Adds an explicit -h "help" option so you can ask for help in ways besides putting in invalid options. 
This allows you to do 'git standup -h' and have it exit success. Useful for a smoke test in things like Mac Homebrew.

Modifies `getopts` usage to avoid syntax errors when invalid options are passed.

The help screen is longer now, so it's only displayed when you do `git standup -h`. Usage errors are kept short, to keep focus on the particular error that `getopts` found.

Now, when you have a bad option supplied, it'll do this:

```
$ git standup -x
/Users/janke/local/opp/git-standup/git-standup: illegal option -- x
Use 'git standup -h' to see usage info
```