### PR TITLE
Fix find warning

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -2,7 +2,7 @@
 
 function usage() {
   cat <<EOS
-Usage: 
+Usage:
   git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-g] [-h]
 
   -a      - Specify author to restrict search to

--- a/git-standup
+++ b/git-standup
@@ -133,7 +133,7 @@ if [[ ! -d ".git" ]]; then
 
   ## Iterate through all the top level directories inside
   ## and look for any git repositories.
-  for DIR in `find . -name .git -type d -maxdepth $MAXDEPTH -mindepth 0`; do
+  for DIR in `find . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
 
     cd "`dirname $DIR`"
     CUR_DIR=`pwd`


### PR DESCRIPTION
I just started using `git-standup` and found it generated a warning when `find` was called. This PR fixes that warning.