### PR TITLE
Add option to run `git fetch --all` before standup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ brew install git-standup
 ## Usage
 
 ```bash
-$ git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-D <date-format>] [-g] [-h]
+$ git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-D <date-format>] [-g] [-h] [-f]
 ```
 
 Below is the description for each of the flags
@@ -46,6 +46,7 @@ Below is the description for each of the flags
 - `-D`      - Specify the date format for "git log" (default: relative)
 - `-h`      - Display the help screen
 - `-g`      - Show if commit is GPG signed or not
+- `-f`      - Fetch the latest commits beforehand
 
 For the basic usage, all you have to do is run `git standup` in a repository or a folder containing multiple repositories
 
@@ -140,6 +141,16 @@ If you want to change this, like I want because here in Dubai working days are n
 
 ```bash
 $ git standup -w "SUN-THU"
+```
+
+## Fetch commits before standup
+
+If you have many repositories that you want to generate a standup for, it may be useful to automatically run `git fetch` before viewing the standup.
+
+If you would like to automatically run `git fetch --all` before printing the standup, you can add the `-f` flag, as show below
+
+```bash
+$ git standup -f
 ```
 
 ## Mixing options

--- a/git-standup
+++ b/git-standup
@@ -4,7 +4,7 @@
 function usage() {
   cat <<EOS
 Usage:
-  git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-g] [-h]
+  git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-g] [-h] [-f]
 
   -a      - Specify author to restrict search to
   -w      - Specify weekday range to limit search to
@@ -13,6 +13,7 @@ Usage:
   -D      - Specify the date format for "git log" (default: relative)
   -h      - Display this help screen
   -g      - Show if commit is GPG signed (G) or not (N)
+  -f      - Fetch the latest commits beforehand
 
 Examples:
   git standup -a "John Doe" -w "MON-FRI" -m 3
@@ -51,9 +52,9 @@ function uncolored() {
   fi
 }
 
-while getopts "hgd:a:w:m:D:" opt; do
+while getopts "hgfd:a:w:m:D:" opt; do
   case $opt in
-    h|d|a|w|m|g|D)
+    h|d|a|w|m|g|D|f)
       declare "option_$opt=${OPTARG:-0}"
       ;;
     \?)
@@ -149,9 +150,24 @@ if [[ ! -d ".git" ]]; then
   ## Set delimiter to newline for the loop
   IFS=$'\n'
 
-  ## Iterate through all the top level directories inside
-  ## and look for any git repositories.
-  for DIR in `find . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
+  ## Recursively search for git repositories
+  DIRS=`find . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`
+
+  if [[ $option_f ]]; then
+    echo "Fetching lastest commits for all repositories"
+
+    for DIR in $DIRS; do
+
+      cd "`dirname $DIR`"
+
+      git fetch --all > /dev/null 2>&1
+
+      cd $BASE_DIR
+
+    done
+  fi
+
+  for DIR in $DIRS; do
 
     cd "`dirname $DIR`"
     CUR_DIR=`pwd`
@@ -175,6 +191,13 @@ if [[ ! -d ".git" ]]; then
   done
 
 else
+
+  if [[ $option_f ]]; then
+    echo "Fetching latest commits"
+
+    git fetch --all > /dev/null 2>&1
+  fi
+
   {
     GITOUT=$(eval ${GIT_LOG_COMMAND} 2>/dev/null )
   } || {


### PR DESCRIPTION
This change is especially useful if you have many projects on the go with multiple contributors.

I'm not sure how verbose you would like the output to be, so I just have a single `echo` statement telling the user that we are running `git fetch`. However it may be useful to give the user feedback on progress if they are fetching multiple repositories.

Similarly, I didn't know if you want to stop execution, print the error and continue on or whatever if `git fetch` fails, so I left it redirecting to `/dev/null`.
