### PR TITLE
Add possibilities to follow symlinks when performing recursive directory search

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ $ brew install git-standup
 ```bash
 $ git standup [-a <author name>] 
               [-w <weekstart-weekend>] 
-              [-d <days-ago>] 
               [-m <max-dir-depth>] 
+              [-L]
+              [-d <days-ago>]
               [-D <date-format>] 
               [-g] 
               [-h]
@@ -48,6 +49,7 @@ Below is the description for each of the flags
 - `-a`      - Specify author to restrict search to
 - `-w`      - Specify weekday range to limit search to
 - `-m`      - Specify the depth of recursive directory search
+- `-L`      - Toggle inclusion of symbolic links in recursive directory search
 - `-d`      - Specify the number of days back to include
 - `-D`      - Specify the date format for "git log" (default: relative)
 - `-h`      - Display the help screen

--- a/git-standup
+++ b/git-standup
@@ -151,7 +151,7 @@ if [[ ! -d ".git" ]]; then
 
   ## Iterate through all the top level directories inside
   ## and look for any git repositories.
-  for DIR in `find . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
+  for DIR in `find -L . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
 
     cd "`dirname $DIR`"
     CUR_DIR=`pwd`

--- a/git-standup
+++ b/git-standup
@@ -9,6 +9,7 @@ Usage:
   -a      - Specify author to restrict search to
   -w      - Specify weekday range to limit search to
   -m      - Specify the depth of recursive directory search
+  -L      - Toggle inclusion of symbolic links in recursive directory search
   -d      - Specify the number of days back to include
   -D      - Specify the date format for "git log" (default: relative)
   -h      - Display this help screen
@@ -51,9 +52,9 @@ function uncolored() {
   fi
 }
 
-while getopts "hgd:a:w:m:D:" opt; do
+while getopts "hgd:a:w:m:D:L" opt; do
   case $opt in
-    h|d|a|w|m|g|D)
+    h|d|a|w|m|g|D|L)
       declare "option_$opt=${OPTARG:-0}"
       ;;
     \?)
@@ -96,6 +97,7 @@ fi
 AUTHOR=`git config user.name`
 SINCE="yesterday"
 MAXDEPTH=2
+INCLUDE_LINKS=
 
 if [[ $option_a ]] ; then
   # In case the parameter
@@ -108,6 +110,10 @@ fi
 
 if [[ $option_m ]] ; then
   MAXDEPTH="$(($option_m + 1))"
+fi
+
+if [[ $option_L ]] ; then
+  INCLUDE_LINKS="-L"
 fi
 
 ## If -d flag is there, use its value for the since
@@ -151,7 +157,7 @@ if [[ ! -d ".git" ]]; then
 
   ## Iterate through all the top level directories inside
   ## and look for any git repositories.
-  for DIR in `find -L . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
+  for DIR in `find $INCLUDE_LINKS . -maxdepth $MAXDEPTH -mindepth 0 -name .git -type d`; do
 
     cd "`dirname $DIR`"
     CUR_DIR=`pwd`


### PR DESCRIPTION
This feature adds a CLI option -L that toggles whether symbolic links should be followed when in the recursive directory search.

I have multiple cloned repositories in different places in my filesystem hierarchy. For ease of access and delimiting of search among other reasons, I keep a `_current_projects` folder containing symbolic links to repositories I am actively working on. This patch allows me to execute `git standup` in my `_current_projects` directory.