### PR TITLE
Add support for whitelisting search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,23 @@ $ git standup -m 3
 ```
 
 ### Directory whitelisting
-If you want to restrict the search path you can whitelist which directories
-to search in by adding them to a `.git-standup-whitelist` file.
+
+If you want to restrict the standup to some paths, you can whitelist them by adding them to a `.git-standup-whitelist` file. For example if you have the below directory structure
+
+    ├── Workspace				# All your projects are here
+    │   ├── project-a           # Some git repository called project-a
+    │   ├── project-b           # Some git repository called project-b
+    │   ├── sketch-files        # Some sketch files
+    │   ├── mockups		          # Some balsamiq mockups
+    │   └── ...                 # etc.
+    └── ...
+
+And you want the `git-standup` to show logs for only `project-a` and `project-b`, you can do that by creating a `.git-standup-whitelist` file under the `Workspace` directory with the below contents and it will only consider these directories for the standup
+
+```
+project-a
+project-b
+```
 
 ## Checking someone else's commits
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ level deep. If you want to increase that, use the `-m` switch.
 $ git standup -m 3
 ```
 
+### Directory whitelisting
+If you want to restrict the search path you can whitelist which directories
+to search in by adding them to a `.git-standup-whitelist` file.
+
 ## Checking someone else's commits
 
 If you want to find out someone else's commits do

--- a/git-standup
+++ b/git-standup
@@ -156,8 +156,14 @@ if [[ ! -d ".git" || -f ".git" ]]; then
   ## Set delimiter to newline for the loop
   IFS=$'\n'
 
+  if [[ -f ".git-standup-whitelist" ]]; then
+      SEARCH_PATH=`cat .git-standup-whitelist`
+  else
+      SEARCH_PATH=.
+  fi
+
   ## Recursively search for git repositories
-  PROJECT_DIRS=`find $INCLUDE_LINKS . -maxdepth $MAXDEPTH -mindepth 0 -name .git`
+  PROJECT_DIRS=`find $INCLUDE_LINKS $SEARCH_PATH -maxdepth $MAXDEPTH -mindepth 0 -name .git`
 
   # Fetch the latest commits, if required
   if [[ $option_f ]]; then


### PR DESCRIPTION
I usually have a directory containing all kinds of git repos so whitelisting repos helps a lot.