### PR TITLE
Show branch names and tags

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -30,7 +30,7 @@ function colored() {
   BOLD=$(tput bold)
   UNDERLINE=$(tput smul)
   NORMAL=$(tput sgr0)
-  GIT_PRETTY_FORMAT='%Cred%h%Creset - %s %Cgreen(%cd) %C(bold blue)<%an>%Creset'
+  GIT_PRETTY_FORMAT='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cd) %C(bold blue)<%an>%Creset'
 
   if [[ $option_g ]] ; then
     GIT_PRETTY_FORMAT="$GIT_PRETTY_FORMAT %C(yellow)gpg: %G?%Creset"


### PR DESCRIPTION
I would like to see branch names and tags for each commit in the output.

Adding `%d` to `git log`'s `--pretty=format:` parameter gives us tags and branch names printed. 

Unfortunately, this is not a perfect solution, as it won't display branch name unless the commit is the last one on the branch. Not sure how could it be solved, or even if it's possible without massive changes in the project.

Any hints on how to improve this will be appreciated.