### PR TITLE
Allow redefining PREFIX and other vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-prefix=/usr/local
-exec_prefix=$(prefix)
-bindir=$(exec_prefix)/bin
-datarootdir=$(prefix)/share
-datadir=$(datarootdir)
-mandir=$(datarootdir)/man
+PREFIX ?= /usr/local
+EXEC_PREFIX ?= $(PREFIX)
+BINDIR ?= $(EXEC_PREFIX)/bin
+DATAROOTDIR ?= $(PREFIX)/share
+DATADIR ?= $(DATAROOTDIR)
+MANDIR ?= $(DATAROOTDIR)/man
 
 # files that need mode 755
-EXEC_FILES=git-standup
+EXEC_FILES = git-standup
 
 .PHONY: all install uninstall
 
@@ -15,10 +15,10 @@ all:
 	@echo "       make uninstall"
 
 install:
-	mkdir -p $(bindir)
-	install -m 0755 $(EXEC_FILES) $(bindir)
+	mkdir -p $(BINDIR)
+	install -m 0755 $(EXEC_FILES) $(BINDIR)
 
 uninstall:
-	test -d $(bindir) && \
-	cd $(bindir) && \
+	test -d $(BINDIR) && \
+	cd $(BINDIR) && \
 	rm -f $(EXEC_FILES)


### PR DESCRIPTION
This allows to do something like `PREFIX=~/.local make install`, so `git-standup` ends where I need to without modifying base system.