### PR TITLE
Add SINCE_DATE environment variable to allow exact date ranges

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -142,7 +142,7 @@ fi
 
 ## Set the necessary variables for standup
 AUTHOR=`git config user.name`
-SINCE="yesterday"
+SINCE=${SINCE_DATE:yesterday}
 MAXDEPTH=2
 INCLUDE_LINKS=
 RAN_FROM_DIR=`pwd`


### PR DESCRIPTION
Currently, the "days ago" option does not act in a manner fit for the purpose of "standups" where some people work. The -d flag uses 24 hour periods, not calendar days. Standup meetings where some people work vary by time of day so that is insufficient for them: They need to report all activity since their last standup. 

If you run the tool at 11 in the morning, -d 2 will miss commits you did at 7 am two days prior

Now you can exactly specify a start date through an environment variable. (You can already specify an exact end date via the "UNTIL_OPT" environment variable, so no changes were made there). For uniformity purposes, this PR adds this SINCE_DATE parameterization the same way GIT_DATE_FORMAT is specified.

Example usage of SINCE_DATE (complex, such as might be used in a script):

     # Requests all commits from 3 days prior starting at 4 in the morning in the eastern timezone of the US
     start=`date -v-3d -u +"%Y-%m-%dT04:00:00-04:00"`;
     SINCE_DATE=$start git-standup -s -m 8 -D format-local:"%a %I:%M %p"; 

Example usage (simple):
  
     # all work done this year (and maybe a late night commit or two on NYE)
     SINCE_DATE=2017-12-31  git-standup 