### PR TITLE
Add support for diffstat of every commit with extra option -c

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -4,7 +4,7 @@
 function usage() {
   cat <<EOS
 Usage:
-  git standup [-a <author name>] [-w <weekstart-weekend>] [-d <since-days-ago>] [-u <until-days-ago>] [-m <max-dir-depth>] [-g] [-h] [-f]
+  git standup [-a <author name>] [-w <weekstart-weekend>] [-d <since-days-ago>] [-u <until-days-ago>] [-m <max-dir-depth>] [-g] [-h] [-f] [-c]
 
   -a      - Specify author to restrict search to
   -w      - Specify weekday range to limit search to
@@ -18,6 +18,7 @@ Usage:
   -f      - Fetch the latest commits beforehand
   -s      - Silences the no activity message (useful when running in a directory having many repositories)
   -r      - Generate a file with the report
+  -c      - Generate a diffstat/change for every matched commit
 
 Examples:
   git standup -a "John Doe" -w "MON-FRI" -m 3
@@ -72,6 +73,7 @@ function runStandup() {
   fi
 
   {
+    echo ${GIT_LOG_COMMAND}
     GITOUT=$(eval ${GIT_LOG_COMMAND} 2>/dev/null )
   } || {
     GITOUT=""
@@ -102,9 +104,9 @@ function runStandup() {
   fi
 }
 
-while getopts "hgfsd:u:a:w:m:D:Lr" opt; do
+while getopts "hgfsd:u:a:w:m:D:Lrc" opt; do
   case $opt in
-    h|d|u|a|w|m|g|D|f|s|L|r)
+    h|d|u|a|w|m|g|D|f|s|L|r|c)
       declare "option_$opt=${OPTARG:-0}"
       ;;
     \?)
@@ -147,6 +149,7 @@ MAXDEPTH=2
 INCLUDE_LINKS=
 RAN_FROM_DIR=`pwd`
 REPORT_FILE_PATH="${RAN_FROM_DIR}/git-standup-report.txt"
+STAT=
 
 # If report is to be generated, remove the existing report file if any
 if [[ ! -z $option_r ]] ; then
@@ -170,6 +173,9 @@ if [[ $option_L ]] ; then
   INCLUDE_LINKS="-L"
 fi
 
+if [[ $option_c ]] ; then
+  STAT="--stat"
+fi
 ## If -d flag is there, use its value for the since
 if [[ $option_d ]] && [[ $option_d -ne 0 ]] ; then
   SINCE="$option_d days ago"
@@ -206,7 +212,7 @@ GIT_LOG_COMMAND="git --no-pager log \
     --oneline
     --pretty=format:'$GIT_PRETTY_FORMAT'
     --date='$GIT_DATE_FORMAT'
-    --color=$COLOR"
+    --color=$COLOR $STAT"
 
 ## For when the command has been run in a non-repo directory
 if [[ ! -d ".git" || -f ".git" ]]; then

--- a/git-standup
+++ b/git-standup
@@ -73,7 +73,6 @@ function runStandup() {
   fi
 
   {
-    echo ${GIT_LOG_COMMAND}
     GITOUT=$(eval ${GIT_LOG_COMMAND} 2>/dev/null )
   } || {
     GITOUT=""


### PR DESCRIPTION
@kamranahmedse , Add a optional '-c' to see diffstat of every commit like below.

[root@centos7 git-standup]# **git-standup -a all -c**
> a75f895 - Remove test echo (3 minutes ago) < Zongpeng Qiao >
 **git-standup | 1 -
 1 file changed, 1 deletion(-)**
> b62d81e - add support for diffstat of every commit with extra option -c (7 minutes ago) < Zongpeng Qiao >
 **git-standup | 14 ++++++++++----
 1 file changed, 10 insertions(+), 4 deletions(-)**
