### PR TITLE
Option to show Author Date instead of Committer Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ git standup [-a <author name>]
             [-s]
             [-r]
             [-c]
+            [-R]
 ```
 
 Here is the detail for each of the options 
@@ -71,6 +72,7 @@ Here is the detail for each of the options
 | s | Silences the no activity message (useful when running in a directory having many repositories) |
 | c | Show diff-stat for every matched commit
 | r | Generates the standup report file `git-standup-report.txt` in the current directory |
+| R | Display the author date instead of the committer date |
 
 For the basic usage, all you have to do is run `git standup` in a repository or a folder containing multiple repositories
 

--- a/git-standup
+++ b/git-standup
@@ -44,7 +44,6 @@ function colored() {
   fi
 
   GIT_PRETTY_FORMAT="%Cred%h%Creset - %s %Cgreen($GIT_PRETTY_DATE) %C(bold blue)<%an>%Creset"
-echo $GIT_PRETTY_FORMAT
   COLOR=always
 
   if [[ $option_g ]] ; then

--- a/git-standup
+++ b/git-standup
@@ -21,6 +21,7 @@ Usage:
   -c      - Show diffstat for every matched commit
   -A      - List commits after this date
   -B      - List commits before this date
+  -R      - Display the author date instead of the committer date
 
 Examples:
   git standup -a "John Doe" -w "MON-FRI" -m 3
@@ -36,7 +37,14 @@ function colored() {
   BOLD=$(tput bold)
   UNDERLINE=$(tput smul)
   NORMAL=$(tput sgr0)
-  GIT_PRETTY_FORMAT='%Cred%h%Creset - %s %Cgreen(%cd) %C(bold blue)<%an>%Creset'
+
+  GIT_PRETTY_DATE="%cd"
+  if [[ $option_R ]] ; then
+    GIT_PRETTY_DATE="%ad"
+  fi
+
+  GIT_PRETTY_FORMAT="%Cred%h%Creset - %s %Cgreen($GIT_PRETTY_DATE) %C(bold blue)<%an>%Creset"
+echo $GIT_PRETTY_FORMAT
   COLOR=always
 
   if [[ $option_g ]] ; then
@@ -53,7 +61,13 @@ function uncolored() {
   BOLD=""
   UNDERLINE=""
   NORMAL=""
-  GIT_PRETTY_FORMAT='%h - %s (%cd) <%an>'
+
+  GIT_PRETTY_DATE="%cd"
+  if [[ $option_R ]] ; then
+    GIT_PRETTY_DATE="%ad"
+  fi
+
+  GIT_PRETTY_FORMAT="%h - %s ($GIT_PRETTY_DATE) <%an>"
   COLOR=never
 
   if [[ $option_g ]] ; then
@@ -105,9 +119,9 @@ function runStandup() {
   fi
 }
 
-while getopts "hgfsd:u:a:w:m:D:A:B:Lrc" opt; do
+while getopts "hgfsd:u:a:w:m:D:A:B:LrcR" opt; do
   case $opt in
-    h|d|u|a|w|m|g|D|f|s|L|r|A|B|c)
+    h|d|u|a|w|m|g|D|f|s|L|r|A|B|c|R)
       declare "option_$opt=${OPTARG:-0}"
       ;;
     \?)


### PR DESCRIPTION
Solves #92

This sets the author date in GIT_PRETTY_FORMAT if -R option is used

Commit dates change when there are rebases or merges and you want to know when the commit was originally made and not when it was added to a branch or rebased on.

Now we can with the `-R` option

```sh
$ git-standup -D local -R
e75ed6a - Commit Message (Thu Nov 22 11:18:27 2018) <Andre Marcelo-Tanner>
```

```sh
$ git-standup -D local
e75ed6a - Commit Message (Thu Nov 22 13:19:00 2018) <Andre Marcelo-Tanner>
```