### PR TITLE
Add snapcraft support to build snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: git-standup
+base: core18 # the base snap is the execution environment for this snap
+version: git
+summary: Recall what you did on the last working day. 
+description: |
+  git-standup by default it gives you the most common usage 
+  i.e. shows you commits from the last working day in the current 
+  directory and the directories below current level plus it comes 
+  with several options to modify how it behaves.
+  The only requirement is having good commit messages :)
+
+grade: stable
+confinement: strict
+
+parts:
+  git-standup:
+    plugin: nodejs
+    source: .
+    stage-packages:
+      - git
+
+apps:
+  git-standup:
+    command: bin/git-standup
+    plugs:
+      - home
+      - removable-media


### PR DESCRIPTION
git-standup is awesome, thanks for making it. We recently had a team sprint and it was great to be able to summarise all the work done with one command. Love it <3 

During that sprint I created a snap package of git-standup so it can be featured in the [Snap Store](https://snapcraft.io/store), which is a cross-distribution app-store for Linux. Once in the store, it can be easily installed via ‘snap install’ or via GNOME Software or KDE Discover on most distros.

A single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the git-standup project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the git-standup name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of git-standup, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via your existing travis CI / release process.

I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have.
