### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Recall what you did on the last working day ..or be nosy and find what someone else did.
 
-A little tool that I always wanted for myself. I work on several repositories on daily basis and it is mostly difficult for me to remember where I left off in each one of them. I was used to checking the heat map on my Github profile or running git log one by one in each of the projects to note what I did and it seemed to be a bit cumbersome and thus came the `git-standup`. By default it gives you the most common usage i.e. shows you commits from the last working day in the current directory and the directories below current level plus it comes with several options to modify how it behaves.
+A little tool that I always wanted for myself. I work on several repositories on daily basis and it is mostly difficult for me to remember where I left off in each one of them. I was used to checking the heat map on my GitHub profile or running git log one by one in each of the projects to note what I did and it seemed to be a bit cumbersome and thus came the `git-standup`. By default it gives you the most common usage i.e. shows you commits from the last working day in the current directory and the directories below current level plus it comes with several options to modify how it behaves.
 
 The only requirement is having good commit messages :)
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.